### PR TITLE
DO NOT MERGE: This is for the ajax challenge.

### DIFF
--- a/ga-app/app/controllers/comments_controller.rb
+++ b/ga-app/app/controllers/comments_controller.rb
@@ -2,9 +2,15 @@ class CommentsController < ApplicationController
 
   def create
     @comment = Comment.new(comment_params.merge(event_id: params[:event_id], user_id: session[:user_id]))
-    @comment.save!
-    redirect_to Event.find(11)  
-  end 
+    respond_to do |format|
+        puts "In the response block."
+       if @comment.save!
+          format.html {redirect_to Event.find(@comment.event_id), notice: 'Comment posted successfully.'}
+          format.js
+      end
+    end
+  end
+
 
   def destroy
     @comment.destroy

--- a/ga-app/app/views/events/create_comment.js.erb
+++ b/ga-app/app/views/events/create_comment.js.erb
@@ -1,0 +1,1 @@
+$(".comment-list").append( '<%= j render(@comment) %>' )

--- a/ga-app/app/views/events/show.html.erb
+++ b/ga-app/app/views/events/show.html.erb
@@ -7,7 +7,7 @@
   <li>Price: $<%= @event.price %></li>
   <li><%= "#{@event.event_start.strftime("%A, %B %e, %Y")}" %></li>
   <li><%= "#{@event.event_start.strftime("%l:%M%p")}" %></li>
-  
+
   <li><%= @event.description%></li>
   <li>Sign Up By:</li>
   <li><%= "#{@event.signup_end.strftime("%A, %B %e, %Y")}" %></li>
@@ -24,7 +24,7 @@
   <%= button_to "Attend", attendances_path, id: "attend" %>
 <% end %>
 
-<div class="container">
+<div class="container comment-list">
 <h4>Comments Section</h4>
   <% @event.comments.each do |comment| %>
     <div class="container">
@@ -33,7 +33,7 @@
     </div>
   <% end %>
   <h5>Comment on this post:</h5>
-  <%= form_for @comment, url: event_comments_path(@event.id) do |f| %>
+  <%= form_for @comment, remote: true, url: event_comments_path(@event.id) do |f| %>
     <%= f.label :content, "Content:" %><br>
     <%= f.text_area :content, size: '40x10' %><br><br>
     <%= f.submit "Comment" %>
@@ -42,7 +42,7 @@
 
 
 
-<!-- 
+<!--
       t.string :name
       t.text :description
       t.string :category


### PR DESCRIPTION
This is incomplete. General comments:
1) Using Rails form_for you can set remote: true to handle the form in an AJAX way.
2) I tried on comments, and using the remote: true method broke our custom url path somehow (kept getting the template missing error for the comments/create path even though we specify event_comments_path in the url option.
3) respond_to |format| block is set in the controller to determine the appropriate actions based on the response type that we're looking for. html, redirect as normal. js, write a line of js in a corresponding create.js.erb.
4) We are displaying comments by querying the database for all comments with a particular event id. Most examples of ajax show the js appending a partial to the list of comments (or tasks, whatever). If we wanted to keep displaying our comments in the same way, I'm not sure how to write AJAX for it. Seems like appending makes more sense for ajax. 
